### PR TITLE
Mark AST Show instance as covering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 An Idris2 lexer and parser for
 [the DOT language](https://graphviz.org/doc/info/lang.html).
 
-Last testet using Idris2-v0.5.1, commit
-[5c41c818](https://github.com/idris-lang/Idris2/commit/5c41c81883fbc77b59cab4282e2cb6777f934972).
+Last tested using Idris2-v0.5.1, commit
+[c7df4195](https://github.com/idris-lang/Idris2/commit/c7df41958c3651222976140e7dfbf515885ccc1b).
 
 # TODO-list
 

--- a/src/Graphics/DOT/AST.idr
+++ b/src/Graphics/DOT/AST.idr
@@ -77,6 +77,7 @@ data DOT : Type where
 
 
 export
+covering
 Show DOT where
   show (Graph strict type id_ stmtList) =
     "(Gr " ++ show strict ++ show type ++ show id_ ++ show stmtList


### PR DESCRIPTION
Prelude's Show is now total by default, and while the current
implementation is (probably) total, the checker can't handle i.e.
`StmtList : List DOT -> DOT`.

cf. idris2#1170